### PR TITLE
Update php@7.0.rb

### DIFF
--- a/Formula/php@7.0.rb
+++ b/Formula/php@7.0.rb
@@ -38,8 +38,6 @@ class PhpAT70 < Formula
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
 
-  needs :cxx11
-
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     if MacOS.version == :el_capitan || MacOS.version == :sierra


### PR DESCRIPTION
No need to defined required c++11.
See https://github.com/Homebrew/brew/pull/5599 and https://github.com/Homebrew/homebrew-core/pull/36362